### PR TITLE
FEATURE: Add request cache

### DIFF
--- a/Configuration/Caches.yaml
+++ b/Configuration/Caches.yaml
@@ -1,0 +1,5 @@
+CodeQ_ZoomApi_Requests:
+  frontend: Neos\Cache\Frontend\VariableFrontend
+  backend: Neos\Cache\Backend\FileBackend
+  backendOptions:
+    defaultLifetime: 600

--- a/Configuration/Caches.yaml
+++ b/Configuration/Caches.yaml
@@ -2,4 +2,4 @@ CodeQ_ZoomApi_Requests:
   frontend: Neos\Cache\Frontend\VariableFrontend
   backend: Neos\Cache\Backend\FileBackend
   backendOptions:
-    defaultLifetime: 600
+    defaultLifetime: 0

--- a/Configuration/Objects.yaml
+++ b/Configuration/Objects.yaml
@@ -1,0 +1,9 @@
+CodeQ\ZoomApi\Domain\Service\ZoomApiService:
+  properties:
+    requestsCache:
+      object:
+        factoryObjectName: Neos\Flow\Cache\CacheManager
+        factoryMethodName: getCache
+        arguments:
+          1:
+            value: CodeQ_ZoomApi_Requests

--- a/README.md
+++ b/README.md
@@ -34,3 +34,19 @@ CodeQ.ZoomApi.getRecordings(Date.create('2021-01-01'), Date.now())
 ```
 
 Be aware, that this helper currently does not implement caching.
+
+## Performance and Caching
+
+Beware, that the package does not cache the requests by default. Thus, using these Eel helpers on
+heavily frequented pages can lead to rate limit issues with the Zoom API. This package provides
+a request cache to tackle that issue. 
+
+By default, the cache is disabled. To enable the cache, configure the lifetime at your convenience:
+
+```yaml
+CodeQ_ZoomApi_Requests:
+  backendOptions:
+    defaultLifetime: 600 # e.g. 60 seconds * 10 minutes = 600 seconds
+```
+
+Of course, you can also switch to a different cache backend at your convenience.


### PR DESCRIPTION
These changes add a cache to avoid overshooting the rate limit by the Zoom API. By default, the cache is disaabled and can be enabled by setting the lifetime to a value larger than zero:

```yaml
CodeQ_ZoomApi_Requests:
  backendOptions:
    defaultLifetime: 600 # e.g. 60 seconds * 10 minutes = 600 seconds
```