### PR TITLE
BUGFIX: Fix cache entry identifier generation

### DIFF
--- a/Classes/Domain/Service/ZoomApiService.php
+++ b/Classes/Domain/Service/ZoomApiService.php
@@ -101,6 +101,13 @@ class ZoomApiService
      */
     public function getRecordings(mixed $from, mixed $to, bool $skipCache = false): array
     {
+        $cacheEntryIdentifier = sprintf('recordings_%s_%s', is_string($from) ? $from : $from->format('Y-m-d'), is_string($to) ? $to : $to->format('Y-m-d'));
+
+        /** @var array|bool $recordings */
+        if (!$skipCache && ($recordings = $this->requestsCache->get($cacheEntryIdentifier)) !== false) {
+            return $recordings;
+        }
+
         if (is_string($from)) {
             $from = new DateTimeImmutable($from);
         } elseIf ($from instanceof DateTime) {
@@ -111,12 +118,6 @@ class ZoomApiService
             $to = new DateTimeImmutable($to);
         } elseIf ($to instanceof DateTime) {
             $to = DateTimeImmutable::createFromMutable($to);
-        }
-
-        $cacheEntryIdentifier = sprintf('recordings_%s_%s', $from->format('U'), $to->format('U'));
-        /** @var array|bool $recordings */
-        if (!$skipCache && ($recordings = $this->requestsCache->get($cacheEntryIdentifier)) !== false) {
-            return $recordings;
         }
 
         if ($from > $to) {


### PR DESCRIPTION
If the `to` parameter is a string with value `now`, the caching would have been ineffective as it incorporated the actual timestamp of the current now-value into the cache entry identifier. Now, the exact argument values are used instead.